### PR TITLE
Atlas

### DIFF
--- a/data/2019-08-08/config.json
+++ b/data/2019-08-08/config.json
@@ -195,7 +195,7 @@
         "timeMarginLeft": 20,
         "timeSpacing": 1000,
         "maxTimeGap": 0.02,
-        "minLabelTimeGap": 0.005,
+        "minLabelTimeGap": 0.007,
         "timeUnit": "secondsSinceStart"
     }
 }

--- a/data/2019-08-08/config.json
+++ b/data/2019-08-08/config.json
@@ -4,8 +4,8 @@
             "id": "App1A",
             "name": "App2A",
             "ip": "10.7.156.75",
-            "host_type": "APP",
-            "sort_nudge": 1,
+            "hostType": "APP",
+            "sortNudge": 1,
             "displayOptions": {
                 "backgroundColor": "#297373"
             }
@@ -14,8 +14,8 @@
             "id": "App2A",
             "name": "App2A",
             "ip": "10.12.10.75",
-            "host_type": "APP",
-            "sort_nudge": 1,
+            "hostType": "APP",
+            "sortNudge": 1,
             "displayOptions": {
                 "backgroundColor": "#297373"
             }
@@ -24,8 +24,8 @@
             "id": "Admin2A",
             "name": "Admin2A",
             "ip": "10.12.10.68",
-            "host_type": "ADMIN",
-            "sort_nudge": 2,
+            "hostType": "ADMIN",
+            "sortNudge": 2,
             "displayOptions": {
                 "backgroundColor": "#0197F6"
             }
@@ -34,86 +34,110 @@
             "id": "MIS2A",
             "name": "MIS2A",
             "ip": "10.12.10.84",
-            "host_type": "MIS",
-            "sort_nudge": 10
+            "hostType": "MIS",
+            "sortNudge": 10
         },
         {
             "id": "ELM1A",
             "name": "ELM1A",
             "ip": "10.7.156.68",
-            "host_type": "ELM",
-            "sort_nudge": 3
+            "hostType": "ELM",
+            "sortNudge": 3
         },
         {
             "id": "REC1A",
             "name": "REC1A",
             "ip": "10.7.156.95",
-            "host_type": "REC",
-            "sort_nudge": 11
+            "hostType": "REC",
+            "sortNudge": 11
         },
         {
             "id": "MIS1A",
             "name": "MIS1A",
             "ip": "10.7.156.92",
-            "host_type": "MIS",
-            "sort_nudge": 10
+            "hostType": "MIS",
+            "sortNudge": 10
         },
         {
             "id": "GL1A",
             "name": "GL1A",
             "ip": "10.7.156.86",
-            "host_type": "GA",
-            "sort_nudge": 6
+            "hostType": "GA",
+            "sortNudge": 6
         },
         {
-            "id": "PVApp",
-            "name": "PV-App",
+            "id": "GodzillaApp",
+            "name": "Godzilla App",
             "ip": "10.10.10.103",
-            "host_type": "APP",
-            "sort_nudge": 1,
+            "hostType": "APP",
+            "sortNudge": 1,
             "displayOptions": {
                 "backgroundColor": "#ff8080"
             }
         },
         {
-            "id": "PVAdmin",
-            "name": "PV-Admin",
+            "id": "GodzillaAdm",
+            "name": "Godzilla Adm",
             "ip": "10.10.10.100",
-            "host_type": "ADMIN",
-            "sort_nudge": 3,
+            "hostType": "ADMIN",
+            "sortNudge": 3,
             "displayOptions": {
                 "backgroundColor": "#668000",
                 "fontColor": "#ffffff"
             }
         },
         {
-            "id": "PVRedAB",
+            "id": "AtlasAdmA",
+            "name": "AtlasA Adm",
+            "ip": "10.10.6.100",
+            "hostType": "ADMIN",
+            "sortNudge": 4,
+            "displayOptions": {
+                "backgroundColor": "#1985A1",
+                "fontColor": "#ffffff"
+            }
+        },
+        {
+            "id": "AtlasAppA",
+            "name": "AtlasA App",
+            "ip": "10.10.6.103",
+            "hostType": "APP",
+            "sortNudge": 4,
+            "displayOptions": {
+                "backgroundColor": "#4C5C68",
+                "fontColor": "#ffffff"
+            }
+        },
+        {
+            "id": "RedABAdm",
             "name": "RedAB",
             "ip": "10.10.5.100",
-            "host_type": "ADMIN",
-            "sort_nudge": 4,
+            "hostType": "ADMIN",
+            "sortNudge": 4,
             "displayOptions": {
                 "backgroundColor": "#d45500",
                 "fontColor": "#ffffff"
-            }
+            },
+            "description": "Will's computer"
         },
         {
-            "id": "PVAdmin7",
-            "name": "Admin-Debug",
+            "id": "MiniBeastAdm",
+            "name": "MiniBeast (Dbg)",
             "ip": "10.10.7.100",
-            "host_type": "ADMIN",
-            "sort_nudge": 5,
+            "hostType": "ADMIN",
+            "sortNudge": 5,
             "displayOptions": {
                 "backgroundColor": "#ff0073",
                 "fontColor": "#ffffff"
-            }
+            },
+            "description": "EVL logging level is set to debug"
         },
         {
-            "id": "PVSierra",
+            "id": "SierraAdm",
             "name": "Sierra",
             "ip": "10.10.8.100",
-            "host_type": "ADMIN",
-            "sort_nudge": 20,
+            "hostType": "ADMIN",
+            "sortNudge": 20,
             "displayOptions": {
                 "backgroundColor": "#ffb380"
             }
@@ -122,18 +146,18 @@
             "id": "PVatest",
             "name": "a_test",
             "ip": "10.10.5.181",
-            "host_type": "ADMIN",
-            "sort_nudge": 21,
+            "hostType": "ADMIN",
+            "sortNudge": 21,
             "displayOptions": {
                 "backgroundColor": "#ffcc00"
             }
         },
         {
-            "id": "PVVenom",
+            "id": "VenomAdm",
             "name": "Venom",
             "ip": "10.10.14.100",
-            "host_type": "ADMIN",
-            "sort_nudge": 22,
+            "hostType": "ADMIN",
+            "sortNudge": 22,
             "displayOptions": {
                 "backgroundColor": "#000000",
                 "fontColor": "#ffffff"

--- a/dsd/data/template.svg
+++ b/dsd/data/template.svg
@@ -15,8 +15,13 @@
     function show_capture_info(e)
     {
         window.alert(JSON.stringify(e));
-        <!-- 'time=' + e.time + ', type=' + e.eventType + ', sendFrame='"2019-08-08 15:20:07.899711" event-type="CDRtype1" send-frame="10861" ack-frame="10862" ack-time="44.164221" />'); -->
     }
+
+    function show_host_info(desc)
+    {
+        window.alert(desc);
+    }
+
 // ]]>
   </script>
   <defs

--- a/dsd/loaddata.py
+++ b/dsd/loaddata.py
@@ -325,7 +325,7 @@ def query_logs(capture_filename, hosts, event_type_names, event_types, settings=
             request_frame = int(p['http'].request_in)
             e = next((e for e in events if e.frame_id == request_frame), None)
             if e:
-                e.ack_time = float(p['tcp'].time_relative)
+                e.ack_time = float(p['http'].time)
                 e.ack_frame_id = int(p.number)
             else:
                 if verbose:

--- a/dsd/queryLogs.py
+++ b/dsd/queryLogs.py
@@ -76,6 +76,10 @@ def main():
 
     ld.filter_hosts(hosts=hosts, events=events)
 
+    if not len(events):
+        print('No events were found for the selected hosts: %s'%(', '.join(hosts) if len(hosts) else '[no matched hosts]'))
+        return
+
     if args.events_outfile:
         ld.write_events(filename=args.events_outfile, events=events)
 

--- a/dsd/queryLogs.py
+++ b/dsd/queryLogs.py
@@ -50,7 +50,7 @@ def main():
         metavar='TEMPLATE_FILE',
         dest='template',
         action='store',
-        default='data/template.svg',
+        required=False,
         type=ld.argparse_file_exists,
         help='Template SVG file, required if generating an SVG'
     )

--- a/samples/sample1/config.json
+++ b/samples/sample1/config.json
@@ -4,8 +4,8 @@
             "id": "App1A",
             "name": "App2A",
             "ip": "10.7.156.75",
-            "host_type": "APP",
-            "sort_nudge": 1,
+            "hostType": "APP",
+            "sortNudge": 1,
             "displayOptions": {
                 "backgroundColor": "#297373"
             }
@@ -14,8 +14,8 @@
             "id": "App2A",
             "name": "App2A",
             "ip": "10.12.10.75",
-            "host_type": "APP",
-            "sort_nudge": 1,
+            "hostType": "APP",
+            "sortNudge": 1,
             "displayOptions": {
                 "backgroundColor": "#297373"
             }
@@ -24,8 +24,8 @@
             "id": "Admin2A",
             "name": "Admin2A",
             "ip": "10.12.10.68",
-            "host_type": "ADMIN",
-            "sort_nudge": 2,
+            "hostType": "ADMIN",
+            "sortNudge": 2,
             "displayOptions": {
                 "backgroundColor": "#0197F6"
             }
@@ -34,112 +34,38 @@
             "id": "MIS2A",
             "name": "MIS2A",
             "ip": "10.12.10.84",
-            "host_type": "MIS",
-            "sort_nudge": 10
+            "hostType": "MIS",
+            "sortNudge": 10
         },
         {
             "id": "ELM1A",
             "name": "ELM1A",
             "ip": "10.7.156.68",
-            "host_type": "ELM",
-            "sort_nudge": 3
+            "hostType": "ELM",
+            "sortNudge": 3
         },
         {
             "id": "REC1A",
             "name": "REC1A",
             "ip": "10.7.156.95",
-            "host_type": "REC",
-            "sort_nudge": 11
+            "hostType": "REC",
+            "sortNudge": 11
         },
         {
             "id": "MIS1A",
             "name": "MIS1A",
             "ip": "10.7.156.92",
-            "host_type": "MIS",
-            "sort_nudge": 10
+            "hostType": "MIS",
+            "sortNudge": 10
         },
         {
             "id": "GL1A",
             "name": "GL1A",
             "ip": "10.7.156.86",
-            "host_type": "GA",
-            "sort_nudge": 6
-        },
-        {
-            "id": "PVApp",
-            "name": "PV-App",
-            "ip": "10.10.10.103",
-            "host_type": "APP",
-            "sort_nudge": 1,
-            "displayOptions": {
-                "backgroundColor": "#ff8080"
-            }
-        },
-        {
-            "id": "PVAdmin",
-            "name": "PV-Admin",
-            "ip": "10.10.10.100",
-            "host_type": "ADMIN",
-            "sort_nudge": 3,
-            "displayOptions": {
-                "backgroundColor": "#668000",
-                "fontColor": "#ffffff"
-            }
-        },
-        {
-            "id": "PVRedAB",
-            "name": "RedAB",
-            "ip": "10.10.5.100",
-            "host_type": "ADMIN",
-            "sort_nudge": 4,
-            "displayOptions": {
-                "backgroundColor": "#d45500",
-                "fontColor": "#ffffff"
-            }
-        },
-        {
-            "id": "PVAdmin7",
-            "name": "Admin-Debug",
-            "ip": "10.10.7.100",
-            "host_type": "ADMIN",
-            "sort_nudge": 5,
-            "displayOptions": {
-                "backgroundColor": "#ff0073",
-                "fontColor": "#ffffff"
-            }
-        },
-        {
-            "id": "PVSierra",
-            "name": "Sierra",
-            "ip": "10.10.8.100",
-            "host_type": "ADMIN",
-            "sort_nudge": 20,
-            "displayOptions": {
-                "backgroundColor": "#ffb380"
-            }
-        },
-        {
-            "id": "PVatest",
-            "name": "a_test",
-            "ip": "10.10.5.181",
-            "host_type": "ADMIN",
-            "sort_nudge": 21,
-            "displayOptions": {
-                "backgroundColor": "#ffcc00"
-            }
-        },
-        {
-            "id": "PVVenom",
-            "name": "Venom",
-            "ip": "10.10.14.100",
-            "host_type": "ADMIN",
-            "sort_nudge": 22,
-            "displayOptions": {
-                "backgroundColor": "#000000",
-                "fontColor": "#ffffff"
-            }
+            "hostType": "GA",
+            "sortNudge": 6
         }
-    ],
+     ],
     "eventTypes": [
         {
             "eventType": "StartCall",


### PR DESCRIPTION
- Fixed the ACK received time
- Style tweaks for the test cases in `data/`
- Fixed error when all hosts are filtered out
- Added thicker stroke around `ADMIN` type hosts for clarity (as often names aren't enough)
- Added a description field to hosts that can be seen with an `onClick` event to add extra info.  Rudimentary for now until I know whether it's useful and implemented in a desirable way.