### PR TITLE
Fixed ACK times

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Note that the SVG events currently have a `onclick` action that calls a function
 ## Limitations
 
 - Written quickly and for a purpose, so some aspects (like having a template) do not generalise well
-- Written for my current company, so we search for company specific `events` in the packages, so not generalisable
-- Is not based on any SVG library or anything, it pretty much just uses string manipulation to build an SVG file (the code doesn't know any SVG semantics, so it wouldn't be easy to change any of the shapes or make very different diagrams.)
+- Contains Solacom specific 'objects', searches for I3 events, _etc_. - not generalisable
+- Is not based on any SVG library or anything, it pretty much just uses string manipulation to build an SVG file (the code doesn't know any SVG semantics, so it wouldn't be easy to change any of the shapes or make very different diagrams.  There has been a little work to change this though)
 
 ## Setup
 
@@ -31,6 +31,17 @@ The values in the `settings` block are defined as:
 - `maxTimeGap`: The maximum allowable space (in seconds) between two events.  Subsequent events with a larger spacing than this will have their spacing collapsed to this value.  The goal of this is to have high resolution time lines without gigantic empty vertical gaps.
 - `minLabelTimeGap`: The minimum amount of time between two events for a time label to appear.  The goal of this is to remove overlapping time lables.  _e.g._ If events `A` and `B` occur within 0.005 s, do not show a time label for event `B`
 - `timeUnit`: Display style of the time label, only supported value currently is `secondsSinceStart`
+
+### Install
+
+All installations are encouraged to be done in a Python3 virtual enviroment.
+
+#### Install for source
+
+Clone the repo, and in the base directory:
+```sh
+python setup.py install
+````
 
 ## Run
 
@@ -66,3 +77,8 @@ generateSequenceDiag                    \
 # Notes
 
 This repo includes some setup config files, data, and README files for particular cases.  These were included as an example of steps taken to diagnose issues (that and I'm not sure where else to save them. :) )
+
+# Developer Notes
+
+- `tspan` objects have been converted into a class as a first step towards converting most/all of the tags into objects.  Once this transformation is complete, the code might be clean enough to leverage a proper SVG package.
+- The SvgObject hierarchy needs to be refactored a little now that a `tspan` class exists.  Types such as Events, Hosts, _etc_ should be in their own library, separate from classes such as `tspan`.

--- a/data/2019-08-08/config.json
+++ b/data/2019-08-08/config.json
@@ -207,7 +207,11 @@
         "maxTimeGap": 0.02,
         "minLabelTimeGap": 0.007,
         "timeUnit": "secondsSinceStart",
+        "ackThresholdFast": 0.001,
         "ackThresholdSlow": 0.002,
-        "ackThresholdVerySlow": 0.010
+        "ackThresholdSlowColor": "#d45500",
+        "ackThresholdVerySlow": 0.010,
+        "ackThresholdVerySlowColor": "#ff2a2a"
+
     }
 }

--- a/data/2019-08-08/config.json
+++ b/data/2019-08-08/config.json
@@ -206,6 +206,8 @@
         "timeSpacing": 1000,
         "maxTimeGap": 0.02,
         "minLabelTimeGap": 0.007,
-        "timeUnit": "secondsSinceStart"
+        "timeUnit": "secondsSinceStart",
+        "ackThresholdSlow": 0.002,
+        "ackThresholdVerySlow": 0.010
     }
 }

--- a/data/2019-08-08/config.json
+++ b/data/2019-08-08/config.json
@@ -67,7 +67,7 @@
         },
         {
             "id": "GodzillaApp",
-            "name": "Godzilla App",
+            "name": "Godzilla",
             "ip": "10.10.10.103",
             "hostType": "APP",
             "sortNudge": 1,
@@ -88,10 +88,10 @@
         },
         {
             "id": "AtlasAdmA",
-            "name": "AtlasA Adm",
+            "name": "Atlas",
             "ip": "10.10.6.100",
             "hostType": "ADMIN",
-            "sortNudge": 4,
+            "sortNudge": 8,
             "displayOptions": {
                 "backgroundColor": "#1985A1",
                 "fontColor": "#ffffff"
@@ -99,7 +99,7 @@
         },
         {
             "id": "AtlasAppA",
-            "name": "AtlasA App",
+            "name": "Atlas",
             "ip": "10.10.6.103",
             "hostType": "APP",
             "sortNudge": 4,
@@ -122,15 +122,25 @@
         },
         {
             "id": "MiniBeastAdm",
-            "name": "MiniBeast (Dbg)",
+            "name": "MiniBeast",
             "ip": "10.10.7.100",
             "hostType": "ADMIN",
             "sortNudge": 5,
             "displayOptions": {
                 "backgroundColor": "#ff0073",
                 "fontColor": "#ffffff"
-            },
-            "description": "EVL logging level is set to debug"
+            }
+        },
+        {
+            "id": "MiniBeastAppA",
+            "name": "MiniBeast",
+            "ip": "10.10.7.103",
+            "hostType": "APP",
+            "sortNudge": 2,
+            "displayOptions": {
+                "backgroundColor": "#ff0073",
+                "fontColor": "#ffffff"
+            }
         },
         {
             "id": "SierraAdm",

--- a/dsd/data/template.svg
+++ b/dsd/data/template.svg
@@ -29,7 +29,7 @@
     <marker
        inkscape:isstock="true"
        style="overflow:visible;"
-       id="Arrow2MendR"
+       id="ArrowRightNormal"
        refX="0.0"
        refY="0.0"
        orient="auto"
@@ -43,7 +43,7 @@
     <marker
        inkscape:isstock="true"
        style="overflow:visible;"
-       id="Arrow2MendX"
+       id="ArrowRightSlow"
        refX="0.0"
        refY="0.0"
        orient="auto"
@@ -51,7 +51,7 @@
       <path
          transform="scale(0.6) rotate(180) translate(0,0)"
          d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
-         style="stroke-linejoin:round;stroke-opacity:1;fill-rule:evenodd;fill-opacity:1;stroke:#506b83;stroke-width:0.625;fill:#c87137"
+         style="stroke-linejoin:round;stroke-opacity:1;fill-rule:evenodd;fill-opacity:1;stroke:#c87137;stroke-width:0.625;fill:#c87137"
          id="path8002" />
     </marker>
     <marker
@@ -59,7 +59,7 @@
        orient="auto"
        refY="0.0"
        refX="0.0"
-       id="Arrow2Mend"
+       id="ArrowRightVerySlow"
        style="overflow:visible;"
        inkscape:isstock="true">
       <path

--- a/dsd/data/template.svg
+++ b/dsd/data/template.svg
@@ -27,44 +27,46 @@
   <defs
      id="defs2">
     <marker
-       style="overflow:visible"
-       id="TriangleOutL"
+       inkscape:isstock="true"
+       style="overflow:visible;"
+       id="Arrow2MendR"
        refX="0.0"
        refY="0.0"
-       orient="auto">
+       orient="auto"
+       inkscape:stockid="Arrow2MendR">
       <path
-         transform="scale(0.8)"
-         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
-         d="M 5.77,0.0 L -2.88,5.0 L -2.88,-5.0 L 5.77,0.0 z "
-         id="path4695" />
+         transform="scale(0.6) rotate(180) translate(0,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="stroke-linejoin:round;stroke-opacity:1;fill-rule:evenodd;fill-opacity:1;stroke:#506b83;stroke-width:0.625;fill:#506b83"
+         id="path6573" />
     </marker>
     <marker
-       inkscape:stockid="Arrow2Lend"
+       inkscape:isstock="true"
+       style="overflow:visible;"
+       id="Arrow2MendX"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2MendX">
+      <path
+         transform="scale(0.6) rotate(180) translate(0,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="stroke-linejoin:round;stroke-opacity:1;fill-rule:evenodd;fill-opacity:1;stroke:#506b83;stroke-width:0.625;fill:#c87137"
+         id="path8002" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Mend"
        orient="auto"
        refY="0.0"
        refX="0.0"
-       id="marker9721"
+       id="Arrow2Mend"
        style="overflow:visible;"
        inkscape:isstock="true">
       <path
-         id="path9719"
+         id="path6326"
          style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#ff0000;stroke-opacity:1;fill:#ff0000;fill-opacity:1"
          d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
-         transform="scale(1.1) rotate(180) translate(1,0)" />
-    </marker>
-    <marker
-       inkscape:stockid="Arrow2Lend"
-       orient="auto"
-       refY="0.0"
-       refX="0.0"
-       id="Arrow2Lend"
-       style="overflow:visible;"
-       inkscape:isstock="true">
-      <path
-         id="path8747"
-         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#ff0000;stroke-opacity:1;fill:#ff0000;fill-opacity:1"
-         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
-         transform="scale(1.1) rotate(180) translate(1,0)" />
+         transform="scale(0.6) rotate(180) translate(0,0)" />
     </marker>
   </defs>
   <metadata

--- a/dsd/loaddata.py
+++ b/dsd/loaddata.py
@@ -13,22 +13,43 @@ import pyshark
 
 import dsd.svgobjs as so
 
+class Settings(object):
+    """ Config object to hold various settings """
+
+    def __init__(self, data):
+        for k,v in data.items():
+            setattr(self, so.JsonSerializatble.json2py_name(k), v)
+
+    @classmethod
+    def from_json(cls, data):
+        # Defaults on Settings (until it's its own object)
+        defaults = {
+            'hostSpacing':      60,   # mm
+            'timeMarginLeft':   20,   # mm
+            'timeSpacing':      25,   # s
+            'minLabelTimeGap':  0.01, # s
+            'maxTimeGap':       2,    # s
+            'timeUnit':         'secondsSinceStart',
+
+            # Ack time thresholds
+            'ackThresholdSlow': 0.001, # s
+            'ackThresholdVery': 0.010, # s
+        }
+
+        for k,v in defaults.items():
+            if k not in data:
+                data[k] = v
+
+        return cls(data=data)
+
 class ConfigFile(object):
     """ Object representing the config file """
 
     @classmethod
     def from_json(cls, data):
+        settings    = Settings.from_json(data['settings'])
         hosts       = list(map(so.Host.from_json,       data['hosts']))
-        event_types = list(map(so.EventType.from_json, data['eventTypes']))
-        settings    = data['settings']
-
-        # Defaults on Settings (until it's its own object)
-        if 'hostSpacing'     not in settings: settings['hostSpacing']     = 60
-        if 'timeMarginLeft'  not in settings: settings['timeMarginLeft']  = 20
-        if 'timeSpacing'     not in settings: settings['timeSpacing']     = 25
-        if 'minLabelTimeGap' not in settings: settings['minLabelTimeGap'] = 0.01
-        if 'maxTimeGap'      not in settings: settings['maxTimeGap']      = 2
-        if 'timeUnit'        not in settings: settings['timeUnit']        = 'secondsSinceStart'
+        event_types = list(map(so.EventType.from_json,  data['eventTypes']))
 
         return hosts, event_types, settings
 
@@ -83,7 +104,8 @@ def read_events(filename, hosts, event_types, settings, verbose=False):
                 if not len(ack_frame_id):
                     ack_frame_id = None
 
-            data.append(so.Event(
+            e = so.Event(
+                settings     = settings,
                 time         = datetime.datetime.strptime(row[0], '%Y-%m-%d %H:%M:%S.%f'),
                 src          = src,
                 dst          = dst,
@@ -91,7 +113,8 @@ def read_events(filename, hosts, event_types, settings, verbose=False):
                 ack_time     = ack_time,
                 frame_id     = frame_id,
                 ack_frame_id = ack_frame_id,
-            ))
+            )
+            data.append(e)
 
     so.Event.sort_and_process(events=data, settings=settings)
 

--- a/dsd/loaddata.py
+++ b/dsd/loaddata.py
@@ -32,8 +32,12 @@ class Settings(object):
             'timeUnit':         'secondsSinceStart',
 
             # Ack time thresholds
-            'ackThresholdSlow': 0.001, # s
-            'ackThresholdVery': 0.010, # s
+            'ackThresholdFast':     0.001, # s
+            'ackThresholdSlow':     0.001, # s
+            'ackThresholdVerySlow': 0.010, # s
+
+            # SVG output type
+            'svg_type':         so.SvgType.PLAIN
         }
 
         for k,v in defaults.items():

--- a/dsd/queryLogs.py
+++ b/dsd/queryLogs.py
@@ -62,8 +62,12 @@ def main():
     # Match the user entered hosts to the configured hosts
     hosts=ld.match_hosts(all_hosts, args.hosts)
 
-    if args.verbose:
-        print('Examining events %s between %s'%(', '.join(args.events), ', '.join([str(x) for x in hosts])))
+    if not len(hosts):
+        print('No matched hosts')
+        return
+    else:
+        if args.verbose:
+            print('Examining events between %s'%(' '.join([str(x) for x in hosts])))
 
     events = ld.query_logs(
         capture_filename=args.capture_filename,
@@ -74,11 +78,15 @@ def main():
         verbose=args.verbose
     )
 
+    # Filter out hosts not used in any events
     ld.filter_hosts(hosts=hosts, events=events)
 
     if not len(events):
         print('No events were found for the selected hosts: %s'%(', '.join(hosts) if len(hosts) else '[no matched hosts]'))
         return
+    else:
+        if args.verbose:
+            print('Examining %d events between hosts %s'%(len(events), ' '.join([str(x) for x in hosts])))
 
     if args.events_outfile:
         ld.write_events(filename=args.events_outfile, events=events)

--- a/dsd/svgobjs.py
+++ b/dsd/svgobjs.py
@@ -196,7 +196,7 @@ class Host(SvgObject):
                 return h
             elif h.name.lower() == name_or_ip.lower():
                 return h
-            elif h.name.lower() == name_or_ip.lower():
+            elif h.ip.lower() == name_or_ip.lower():
                 return h
 
         return None

--- a/dsd/svgobjs.py
+++ b/dsd/svgobjs.py
@@ -621,11 +621,11 @@ class Event(SvgObject):
         def arrow_id(e):
             """ Select the proper arrow ID, these are defined in the template """
             if e.event_ack_speed == EventAckSpeed.VERY_SLOW:
-                return 'Arrow2Mend'
+                return 'ArrowRightVerySlow'
             elif e.event_ack_speed == EventAckSpeed.SLOW:
-                return 'Arrow2MendX'
+                return 'ArrowRightSlow'
             else:
-                return 'Arrow2MendR'
+                return 'ArrowRightNormal'
 
 
         event_label = self.event_type.name

--- a/samples/sample1/config.json
+++ b/samples/sample1/config.json
@@ -64,8 +64,116 @@
             "ip": "10.7.156.86",
             "hostType": "GA",
             "sortNudge": 6
+        },
+        {
+            "id": "GodzillaApp",
+            "name": "Godzilla",
+            "ip": "10.10.10.103",
+            "hostType": "APP",
+            "sortNudge": 1,
+            "displayOptions": {
+                "backgroundColor": "#ff8080"
+            }
+        },
+        {
+            "id": "GodzillaAdm",
+            "name": "Godzilla Adm",
+            "ip": "10.10.10.100",
+            "hostType": "ADMIN",
+            "sortNudge": 3,
+            "displayOptions": {
+                "backgroundColor": "#668000",
+                "fontColor": "#ffffff"
+            }
+        },
+        {
+            "id": "AtlasAdmA",
+            "name": "Atlas",
+            "ip": "10.10.6.100",
+            "hostType": "ADMIN",
+            "sortNudge": 4,
+            "displayOptions": {
+                "backgroundColor": "#1985A1",
+                "fontColor": "#ffffff"
+            }
+        },
+        {
+            "id": "AtlasAppA",
+            "name": "Atlas",
+            "ip": "10.10.6.103",
+            "hostType": "APP",
+            "sortNudge": 4,
+            "displayOptions": {
+                "backgroundColor": "#4C5C68",
+                "fontColor": "#ffffff"
+            }
+        },
+        {
+            "id": "RedABAdm",
+            "name": "RedAB",
+            "ip": "10.10.5.100",
+            "hostType": "ADMIN",
+            "sortNudge": 4,
+            "displayOptions": {
+                "backgroundColor": "#d45500",
+                "fontColor": "#ffffff"
+            },
+            "description": "Will's computer"
+        },
+        {
+            "id": "MiniBeastAdm",
+            "name": "MiniBeast",
+            "ip": "10.10.7.100",
+            "hostType": "ADMIN",
+            "sortNudge": 5,
+            "displayOptions": {
+                "backgroundColor": "#ff0073",
+                "fontColor": "#ffffff"
+            }
+        },
+        {
+            "id": "MiniBeastAppA",
+            "name": "MiniBeast",
+            "ip": "10.10.7.103",
+            "hostType": "APP",
+            "sortNudge": 2,
+            "displayOptions": {
+                "backgroundColor": "#ff0073",
+                "fontColor": "#ffffff"
+            }
+        },
+        {
+            "id": "SierraAdm",
+            "name": "Sierra",
+            "ip": "10.10.8.100",
+            "hostType": "ADMIN",
+            "sortNudge": 20,
+            "displayOptions": {
+                "backgroundColor": "#ffb380"
+            }
+        },
+        {
+            "id": "PVatest",
+            "name": "a_test",
+            "ip": "10.10.5.181",
+            "hostType": "ADMIN",
+            "sortNudge": 21,
+            "displayOptions": {
+                "backgroundColor": "#ffcc00"
+            }
+        },
+        {
+            "id": "VenomAdm",
+            "name": "Venom",
+            "ip": "10.10.14.100",
+            "hostType": "ADMIN",
+            "sortNudge": 22,
+            "displayOptions": {
+                "backgroundColor": "#000000",
+                "fontColor": "#ffffff"
+            }
         }
-     ],
+    ],
     "eventTypes": [
         {
             "eventType": "StartCall",


### PR DESCRIPTION
- Creates `tspan` object in a first step to add some semantic SVG data to the code
- Fixed the display of the ACK times
- Added settings `ackThresholdFast`, `ackThresholdSlowColor`, `ackThresholdVerySlowColor`
- Created `Settings` object to hold global config
- Made sure everything has access to the `settings` object (_singleton_'ish) upon or soon after creation)
- Only display ACK times if their slower than `ackThresholdFast`
- Renamed arrows to be more extendable in the future, also added an arrow for every colour.  Soon this should be turned into an object an exported instead of read from the template.
- Added some sample systems in the configs
- Added developer notes into the `README`
- Fixed issue where IPs from the command line weren't matching hosts